### PR TITLE
Add arcdps fallback for EV_ACCOUNT_NAME

### DIFF
--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -276,6 +276,10 @@ void AgentUpdate(EvCombatData* evCbtData)
 		std::scoped_lock lck(Mutex);
 		Self = evAgentUpdate;
 		APIDefs->RaiseEvent("EV_ARCDPS_SELF_JOIN", (void*)&Self);
+		if (AccountName.empty()) {
+			AccountName = Self.account;
+			APIDefs->RaiseEvent("EV_ACCOUNT_NAME", (void*)AccountName.c_str());
+		}
 	}
 }
 


### PR DESCRIPTION
Allows `EV_ACCOUNT_NAME` to work without unofficial extras installed.